### PR TITLE
Added support for Query Defined Tables (Sub-Queries)

### DIFF
--- a/TestScripts/QueryDefinedTable.sql
+++ b/TestScripts/QueryDefinedTable.sql
@@ -1,0 +1,7 @@
+SELECT sub.last_name,
+       sub.first_name
+FROM   (SELECT customer.last_name,
+               customer.first_name
+        FROM   customer
+        WHERE  customer.age > '30') AS sub
+        


### PR DESCRIPTION
In order to support my own uses for this, I needed to be able to correctly examine SQL files that had sub-queries as FROM statements. In order to support this, I added a function to recursively go through the object to find the first table reference within any number of nested sub-queries. I also provided an example file. I have only tested this on SQL code examples I have available, so I am not sure if this introduces issues with other valid SQL or not.